### PR TITLE
Setup API docs generation via FORD

### DIFF
--- a/.github/workflows/APIdocs.yaml
+++ b/.github/workflows/APIdocs.yaml
@@ -1,0 +1,43 @@
+name: API docs generation via FORD
+on:
+  workflow_dispatch: # manual-run
+  push: 
+    branches:
+      - master # foreach push on master
+jobs:
+  CD:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9] # Version of Python we want to use.
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup Graphviz
+      uses: ts-graphviz/setup-graphviz@v1
+
+    - name: Install FORD
+      if: contains( matrix.os, 'ubuntu')
+      run: |
+        python -m pip install --upgrade pip
+        pip install ford
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Generate DOCS
+      run: ford ./docs.config
+
+    - name: Deploy DOCS
+      if: github.ref == 'refs/heads/master'
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: doc      # The folder the action should deploy.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scifor_version.inc
 */test/*.dat
 */test/*.dat.gz
 build*/
+doc/

--- a/docs.config
+++ b/docs.config
@@ -1,0 +1,31 @@
+project: SciFortran
+project_dir: src
+output_dir: doc
+exclude_dir: ./src/arpack
+             ./src/blas
+             ./src/fftpack
+             ./src/lapack
+             ./src/minpack
+             ./src/quadpack
+project_github: https://github.com/QcmPlab/SciFortran
+summary: A library of fortran modules and routines for scientific calculations (*in a way* just like scipy for python)
+author: QcmP Lab members
+author_description: 
+author_pic: https://github.com/QcmPlab/LOGO/releases/download/v1.0/QcmPlab-dark.png
+email: adriano.amaricci@gmail.com
+github: https://github.com/QcmPlab
+display: public
+         protected
+source: true
+sort: src
+docmark: †
+dockmark_alt: ‡
+predocmark: »
+predocmark_alt: ¬
+search: true
+graph: true
+warn: false
+
+-------------
+
+{!README.md!}

--- a/docs.config
+++ b/docs.config
@@ -18,12 +18,12 @@ display: public
          protected
 source: true
 sort: src
-docmark: †
-dockmark_alt: ‡
-predocmark: »
-predocmark_alt: ¬
 search: true
 graph: true
+docmark: ‹
+dockmark_alt: «
+predocmark: ›
+predocmark_alt: »
 warn: false
 
 -------------

--- a/docs.config
+++ b/docs.config
@@ -7,6 +7,9 @@ exclude_dir: ./src/arpack
              ./src/lapack
              ./src/minpack
              ./src/quadpack
+fpp_extensions: f90
+macro: _MPI
+       _SCALAPACK
 project_github: https://github.com/QcmPlab/SciFortran
 summary: A library of fortran modules and routines for scientific calculations (*in a way* just like scipy for python)
 author: QcmP Lab members
@@ -18,12 +21,12 @@ display: public
          protected
 source: true
 sort: src
-search: true
-graph: true
 docmark: ‹
 dockmark_alt: «
 predocmark: ›
 predocmark_alt: »
+search: true
+graph: true
 warn: false
 
 -------------

--- a/src/SF_IOTOOLS/ioread_control.f90
+++ b/src/SF_IOTOOLS/ioread_control.f90
@@ -1,9 +1,15 @@
-  inquire(file=trim(pname),exist=control)
-  if(.not.control)inquire(file=trim(pname)//".gz",exist=control)
-  if(.not.control)then
-     write(*,"(A)")"I can not read : +"//trim(pname)//" SKIP"
-     call sleep(5)
-     return
-  else
-     write(*,"(A,A)")"read:     "//trim(pname)
-  endif
+subroutine ioread_control(pname,control)
+   character(len=*) :: pname
+   logical          :: control
+   !
+   inquire(file=trim(pname),exist=control)
+   if(.not.control)inquire(file=trim(pname)//".gz",exist=control)
+   if(.not.control)then
+      write(*,"(A)")"I can not read : +"//trim(pname)//" SKIP"
+      call sleep(5)
+      return
+   else
+      write(*,"(A,A)")"read:     "//trim(pname)
+   endif
+   !
+end subroutine ioread_control

--- a/src/SF_IOTOOLS/ioread_read_array.f90
+++ b/src/SF_IOTOOLS/ioread_read_array.f90
@@ -4,7 +4,7 @@ subroutine data_readA1_R(pname,Y1)
   real(8),dimension(:)  :: Y1
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -23,7 +23,7 @@ subroutine data_readA1_C(pname,Y1)
   complex(8),dimension(:):: Y1
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -56,7 +56,7 @@ subroutine data_readA2_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -94,7 +94,7 @@ subroutine data_readA2_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -137,7 +137,7 @@ subroutine data_readA3_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -182,7 +182,7 @@ subroutine data_readA3_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -236,7 +236,7 @@ subroutine data_readA4_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -286,7 +286,7 @@ subroutine data_readA4_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -345,7 +345,7 @@ subroutine data_readA5_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -401,7 +401,7 @@ subroutine data_readA5_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -467,7 +467,7 @@ subroutine data_readA6_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -527,7 +527,7 @@ subroutine data_readA6_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -598,7 +598,7 @@ subroutine data_readA7_R(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !
@@ -663,7 +663,7 @@ subroutine data_readA7_C(pname,Y1,order,wspace)
   wspace_= .true.; if(present(wspace))wspace_=wspace
   !
   call file_gunzip(reg(pname))
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   !
   open(free_unit(unit),file=reg(pname))
   !

--- a/src/SF_IOTOOLS/ioread_sread.f90
+++ b/src/SF_IOTOOLS/ioread_sread.f90
@@ -3,7 +3,7 @@ subroutine sreadA1_RR(pname,X,Y1)
   character(len=*)                    :: pname
   real(8),dimension(:)                :: X
   real(8),dimension(size(X))          :: Y1
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   Np=size(X)
   do i=1,Np
@@ -18,7 +18,7 @@ subroutine sreadA1_RC(pname,X,Y1)
   real(8),dimension(:)          :: X
   complex(8),dimension(size(X)) :: Y1
   real(8),dimension(size(X))    :: reY,imY
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   Np=size(X)
   do i=1,Np
@@ -41,7 +41,7 @@ subroutine sreadA2_RR(pname,X,Y1)
   character(len=*)              :: pname
   real(8),dimension(:,:)        :: Y1
   real(8),dimension(size(Y1,2)) :: X
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -62,7 +62,7 @@ subroutine sreadA2_RC(pname,X,Y1)
   complex(8),dimension(:,:)                :: Y1
   real(8),dimension(size(Y1,2))            :: X
   real(8),dimension(size(Y1,1),size(Y1,2)) :: reY,imY
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -89,7 +89,7 @@ subroutine sreadA3_RR(pname,X,Y1)
   character(len=*)              :: pname
   real(8),dimension(:,:,:)      :: Y1
   real(8),dimension(size(Y1,3)) :: X
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -112,7 +112,7 @@ subroutine sreadA3_RC(pname,X,Y1)
   complex(8),dimension(:,:,:)                         :: Y1
   real(8),dimension(size(Y1,3))                       :: X
   real(8),dimension(size(Y1,1),size(Y1,2),size(Y1,3)) :: reY,imY
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -142,7 +142,7 @@ subroutine sreadA4_RR(pname,X,Y1)
   character(len=*)              :: pname
   real(8),dimension(:,:,:,:)    :: Y1
   real(8),dimension(size(Y1,4)) :: X
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -174,7 +174,7 @@ subroutine sreadA4_RC(pname,X,Y1)
        size(Y1,3),&
        size(Y1,4))              :: reY,imY
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   !
@@ -210,7 +210,7 @@ subroutine sreadA5_RR(pname,X,Y1)
   real(8),dimension(:,:,:,:,:)    :: Y1
   real(8),dimension(size(Y1,5))   :: X
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -246,7 +246,7 @@ subroutine sreadA5_RC(pname,X,Y1)
        size(Y1,4),&
        size(Y1,5))                :: reY,imY
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   !
@@ -284,7 +284,7 @@ subroutine sreadA6_RR(pname,X,Y1)
   real(8),dimension(:,:,:,:,:,:)    :: Y1
   real(8),dimension(size(Y1,6))     :: X
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -324,7 +324,7 @@ subroutine sreadA6_RC(pname,X,Y1)
        size(Y1,5),&
        size(Y1,6))                  :: reY,imY
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -365,7 +365,7 @@ subroutine sreadA7_RR(pname,X,Y1)
   real(8),dimension(:,:,:,:,:,:,:)    :: Y1
   real(8),dimension(size(Y1,7))       :: X
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   Ny1=size(Y1,1)
@@ -409,7 +409,7 @@ subroutine sreadA7_RC(pname,X,Y1)
        size(Y1,6),&
        size(Y1,7))                    :: reY,imY
   !
-  include "ioread_control.f90"
+  call ioread_control(pname,control)
   open(free_unit(unit),file=reg(pname))
   !
   !

--- a/src/SF_SPECIAL/special_functions.f90
+++ b/src/SF_SPECIAL/special_functions.f90
@@ -2328,7 +2328,7 @@ subroutine cgama ( x, y, kf, gr, gi )
   !
   !  Discussion:
   !
-  !    This procedcure computes the gamma function ג(z) or ln[ג(z)]
+  !    This procedcure computes the gamma function ־“(z) or ln[־“(z)]
   !    for a complex argument
   !
   !  Licensing:
@@ -2359,8 +2359,8 @@ subroutine cgama ( x, y, kf, gr, gi )
   !    the argument Z.
   !
   !    Input, integer ( kind = 4 ) KF, the function code.
-  !    0 for ln[ג(z)]
-  !    1 for ג(z)
+  !    0 for ln[־“(z)]
+  !    1 for ־“(z)
   !
   !    Output, real ( kind = 8 ) GR, GI, the real and imaginary parts of
   !    the selected function.
@@ -2907,7 +2907,7 @@ subroutine chgubi ( a, b, x, hu, id )
   !  Discussion:
   !
   !    This procedure computes the confluent hypergeometric function
-  !    U(a,b,x) with integer ( kind = 4 ) b ( b = ס1,ס2,... )
+  !    U(a,b,x) with integer ( kind = 4 ) b ( b = ֲ±1,ֲ±2,... )
   !
   !  Licensing:
   !
@@ -8387,10 +8387,10 @@ subroutine cva1 ( kd, m, q, cv )
   !  Parameters:
   !
   !    Input, integer ( kind = 4 ) KD, the case code.
-  !    1, for cem(x,q)  ( m = 0,2,4,תתת )
-  !    2, for cem(x,q)  ( m = 1,3,5,תתת )
-  !    3, for sem(x,q)  ( m = 1,3,5,תתת )
-  !    4, for sem(x,q)  ( m = 2,4,6,תתת )
+  !    1, for cem(x,q)  ( m = 0,2,4,... )
+  !    2, for cem(x,q)  ( m = 1,3,5,... )
+  !    3, for sem(x,q)  ( m = 1,3,5,... )
+  !    4, for sem(x,q)  ( m = 2,4,6,... )
   !
   !    Input, integer ( kind = 4 ) M, the maximum order of the Mathieu functions.
   !
@@ -13858,7 +13858,7 @@ subroutine incog ( a, x, gin, gim, gip )
 
   !*****************************************************************************80
   !
-  !! INCOG computes the incomplete gamma function r(a,x), ,(a,x), P(a,x).
+  !! INCOG computes the incomplete gamma function r(a,x), ־“(a,x), P(a,x).
   !
   !  Licensing:
   !
@@ -13889,7 +13889,7 @@ subroutine incog ( a, x, gin, gim, gip )
   !    Input, real ( kind = 8 ) X, the argument.
   !
   !    Output, real ( kind = 8 ) GIN, GIM, GIP, the values of
-  !    r(a,x), ג(a,x), P(a,x).
+  !    r(a,x), ־“(a,x), P(a,x).
   !
   implicit none
 
@@ -18231,7 +18231,7 @@ subroutine lagzo ( n, x, w )
   !  Discussion:
   !
   !    This procedure computes the zeros of Laguerre polynomial Ln(x) in the 
-  !    interval [0,ל], and the corresponding weighting coefficients for 
+  !    interval [0,גˆ], and the corresponding weighting coefficients for 
   !    Gauss-Laguerre integration.
   !
   !  Licensing:


### PR DESCRIPTION
### Preliminary support for API docs generation via [FORD](https://github.com/Fortran-FOSS-Programmers/ford)

For now we set uncommon UTF-8 characters as `[pre]docmark[_alt]` symbols,
so to (almost)^ deactivate docstring generation: better nothing than a total mess.

^ We say almost cause there is some bug / misunderstanding on how to override
   default dockmark_alt and predockmark_alt symbols, so we still get some noise.

Gradually we'd want to parse and standardize the comments across all the
modules (currently there are many different styles, so whatever marker set
we choose, the output is very messy). There is no need to conform to
the defaults of FORD, but some convention has to be taken (and followed).

Even without docstrings the generated html provides already significant
value: all procedures/types/interfaces are searchable, without the usual
noise that grep or similar tools generate (as calls and references are
picked too), all dependencies / call-graphs / inheritance-graphs / etc.
are generated and nicely displayed in the resulting html, which can be
easily uploaded in a github page (and an action for that has been already
set up).

Some well-defined refactoring has been made to the source code, with the
aim to ease the parsing for FORD (as well as improving the codebase itself).

Specifically:
- fix some non UTF-8 characters within `special_functions.f90` (see 455dff5f6e0193fffa31b816836fb8bcf6085607)
- make `ioread_control.f90` a proper (external) subroutine instead of just an included 'code-snippet' (see a2cd2b7aba019ae411a126b75ec92311ecab7f72)